### PR TITLE
Set --source and --target when available.

### DIFF
--- a/src/env_paths/mod.rs
+++ b/src/env_paths/mod.rs
@@ -15,7 +15,8 @@ pub const ANDROID_SDK_EXTENSION:        &str = "ANDROID_SDK_EXTENSION";
 pub const ANDROID_D8_JAR:               &str = "ANDROID_D8_JAR";
 pub const ANDROID_JAR:                  &str = "ANDROID_JAR";
 pub const JAVA_HOME:                    &str = "JAVA_HOME";
-
+pub const ANDROID_SOURCE_VERSION:       &str = "ANDROID_SOURCE_VERSION";
+pub const ANDROID_TARGET_VERSION:       &str = "ANDROID_TARGET_VERSION";
 
 /// An extension trait for checking if a path exists.
 pub trait PathExt {
@@ -173,4 +174,16 @@ pub fn java_home() -> Option<PathBuf> {
         .and_then(PathExt::path_if_exists)
         .map(PathBuf::from)
         .or_else(find_java_home)
+}
+
+/// Returns the source version for compilation
+/// from `ANDROID_SOURCE_VERSION`,
+pub fn android_source_version() -> Option<String> {
+    env::var(ANDROID_SOURCE_VERSION).ok()
+}
+
+/// Returns the target version for compilation
+/// from `ANDROID_TARGET_VERSION`,
+pub fn android_target_version() -> Option<String> {
+    env::var(ANDROID_TARGET_VERSION).ok()
 }

--- a/src/env_paths/mod.rs
+++ b/src/env_paths/mod.rs
@@ -15,8 +15,8 @@ pub const ANDROID_SDK_EXTENSION:        &str = "ANDROID_SDK_EXTENSION";
 pub const ANDROID_D8_JAR:               &str = "ANDROID_D8_JAR";
 pub const ANDROID_JAR:                  &str = "ANDROID_JAR";
 pub const JAVA_HOME:                    &str = "JAVA_HOME";
-pub const ANDROID_SOURCE_VERSION:       &str = "ANDROID_SOURCE_VERSION";
-pub const ANDROID_TARGET_VERSION:       &str = "ANDROID_TARGET_VERSION";
+pub const JAVA_SOURCE_VERSION:          &str = "JAVA_SOURCE_VERSION";
+pub const JAVA_TARGET_VERSION:          &str = "JAVA_TARGET_VERSION";
 
 /// An extension trait for checking if a path exists.
 pub trait PathExt {
@@ -177,13 +177,13 @@ pub fn java_home() -> Option<PathBuf> {
 }
 
 /// Returns the source version for compilation
-/// from `ANDROID_SOURCE_VERSION`,
-pub fn android_source_version() -> Option<String> {
-    env::var(ANDROID_SOURCE_VERSION).ok()
+/// from `JAVA_SOURCE_VERSION`,
+pub fn java_source_version() -> Option<String> {
+    env::var(JAVA_SOURCE_VERSION).ok()
 }
 
 /// Returns the target version for compilation
-/// from `ANDROID_TARGET_VERSION`,
-pub fn android_target_version() -> Option<String> {
-    env::var(ANDROID_TARGET_VERSION).ok()
+/// from `JAVA_TARGET_VERSION`,
+pub fn java_target_version() -> Option<String> {
+    env::var(JAVA_TARGET_VERSION).ok()
 }

--- a/src/java_build.rs
+++ b/src/java_build.rs
@@ -137,6 +137,14 @@ impl JavaBuild {
             d.add_as_args_to(&mut cmd);
         }
 
+        if let Some(source) = env_paths::android_source_version() {
+            cmd.arg("--source").arg(source);
+        }
+
+        if let Some(target) = env_paths::android_target_version() {
+            cmd.arg("--target").arg(target);
+        }
+
         self.class_paths     .iter().for_each(|p| { cmd.arg("-cp").arg(p); });
         self.source_paths    .iter().for_each(|p| { cmd.arg("-sourcepath").arg(p); });
         self.boot_class_paths.iter().for_each(|p| { cmd.arg("-bootclasspath").arg(p); });

--- a/src/java_build.rs
+++ b/src/java_build.rs
@@ -137,11 +137,11 @@ impl JavaBuild {
             d.add_as_args_to(&mut cmd);
         }
 
-        if let Some(source) = env_paths::android_source_version() {
+        if let Some(source) = env_paths::java_source_version() {
             cmd.arg("--source").arg(source);
         }
 
-        if let Some(target) = env_paths::android_target_version() {
+        if let Some(target) = env_paths::java_target_version() {
             cmd.arg("--target").arg(target);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,10 @@
 //!     already includes an extension, then `ANDROID_SDK_EXTENSION` will be ignored.
 //! * `ANDROID_D8_JAR`: the path to the `d8.jar` file.
 //! * `ANDROID_JAR`: the path to the `android.jar` file.
-//! * `ANDROID_SOURCE_VERSION`: the Java version for source compatibility; 
-//! equivalent to the `--source` javac option.
-//! * `ANDROID_TARGET_VERSION`: the Java version for target compatibility; 
-//! equivalent to the `--target` javac option.
+//! * `JAVA_SOURCE_VERSION`: the Java version for source compatibility; 
+//! equivalent to the `--source` javac option, eg: `17`.
+//! * `JAVA_TARGET_VERSION`: the Java version for target compatibility; 
+//! equivalent to the `--target` javac option, eg: `17`.
 //! * `JAVA_HOME`: the Java SDK directory.
 //!
 //! ## Acknowledgments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,10 @@
 //!     already includes an extension, then `ANDROID_SDK_EXTENSION` will be ignored.
 //! * `ANDROID_D8_JAR`: the path to the `d8.jar` file.
 //! * `ANDROID_JAR`: the path to the `android.jar` file.
+//! * `ANDROID_SOURCE_VERSION`: the Java version for source compatibility; 
+//! equivalent to the `--source` javac option.
+//! * `ANDROID_TARGET_VERSION`: the Java version for target compatibility; 
+//! equivalent to the `--target` javac option.
 //! * `JAVA_HOME`: the Java SDK directory.
 //!
 //! ## Acknowledgments


### PR DESCRIPTION
From the `ANDROID_SOURCE_VERSION` and `ANDROID_RELEASE_VERSION` environment variables.

Closes #1.