### PR TITLE
Fix compilation on Android itself

### DIFF
--- a/src/env_paths/find_android_sdk.rs
+++ b/src/env_paths/find_android_sdk.rs
@@ -30,6 +30,11 @@ pub fn find_android_sdk() -> Option<PathBuf> {
         .into()
 }
 
+#[cfg(target_os = "android")]
+pub fn find_android_sdk() -> Option<PathBuf> {
+    return None
+}
+
 #[cfg(target_os = "windows")]
 /// Returns the path to the current user's home directory on Windows.
 ///


### PR DESCRIPTION
This is clearly not the most common way to build for Android, but I'm experimenting with building on an Android tablet (see https://github.com/dfaure/rust-android-hello-world for howto) and this crate failed to build for lack of an Android implementation of find_android_sdk().

No default installation directory, so setting ANDROID_HOME is required.